### PR TITLE
fix(Inventory): 슬롯 교환 로직 및 방어구 검증 로직 개선

### DIFF
--- a/Source/TinySurvivor/Private/Inventory/TSInventoryMasterComponent.cpp
+++ b/Source/TinySurvivor/Private/Inventory/TSInventoryMasterComponent.cpp
@@ -279,9 +279,18 @@ void UTSInventoryMasterComponent::Internal_TransferItem(
 		// 일반 교환
 		if (bIsFullStack)
 		{
+			// SlotType 백업
+			ESlotType FromSlotType = FromSlot.SlotType;
+			ESlotType ToSlotType = ToSlot.SlotType;
+
+			// 아이템 데이터 교환
 			FSlotStructMaster Temp = FromSlot;
 			FromSlot = ToSlot;
 			ToSlot = Temp;
+
+			// SlotType 복원
+			FromSlot.SlotType = FromSlotType;
+			ToSlot.SlotType = ToSlotType;
 		}
 		else
 		{
@@ -683,12 +692,17 @@ bool UTSInventoryMasterComponent::CanPlaceItemInSlot(
 	// 방어구 아이템 타입 검증
 	if (InventoryType == EInventoryType::Equipment)
 	{
+		if (ItemInfo.Category != EItemCategory::ARMOR)
+		{
+			return false;
+		}
 		const FInventoryStructMaster* Inventory = GetInventoryByType(InventoryType);
 		if (!Inventory)
 		{
 			return false;
 		}
 		ESlotType TargetSlotType = Inventory->InventorySlotContainer[SlotIndex].SlotType;
+
 		if (EquipmentSlotTypes[TargetSlotType] != ItemInfo.ArmorData.EquipSlot)
 		{
 			return false;


### PR DESCRIPTION
슬롯 교환 및 방어구 검증 과정의 데이터 처리 안정성을 강화.
- 슬롯 교환 시 SlotType 정보 백업 및 복원 로직 추가
- 방어구 카테고리 및 장비 슬롯 검증 로직 보완으로 데이터 무결성 보호
- ArmorData의 EquipSlot 속성과 SlotType 비교 로직 오류 수정