### PR TITLE
WorldItem 및 WorldItemPoolSubsystem에 부패(Decay) 처리 임시 연동

### DIFF
--- a/Source/TinySurvivor/Private/Item/System/WorldItemPoolSubsystem.cpp
+++ b/Source/TinySurvivor/Private/Item/System/WorldItemPoolSubsystem.cpp
@@ -1,4 +1,23 @@
 // WorldItemPoolSubsystem.cpp
+/*
+	===============================================================================
+	[ FILE MODIFICATION NOTICE - DECAY SYSTEM INTEGRATION ]
+	작성자: 양한아
+	날짜: 2025/11/21
+	
+	본 파일에는 '부패(Decay) 시스템'을 통합하기 위한 변경이 포함되어 있습니다.
+	해당 변경들은 모두 아래 표기된 주석 블록 내부에 위치합니다:
+	
+		// ■ Decay
+		//[S]=====================================================================================
+			(Decay 관련 통합 코드)
+		//[E]=====================================================================================
+		
+	위 영역 외의 기존 풀링/스폰/인스턴싱 로직은 변경하지 않았습니다.
+	Decay 시스템만 연동한 최소 변경입니다.
+	후속 작업 시 해당 블록을 참고해주세요.
+	===============================================================================
+*/
 
 #include "Item/System/WorldItemPoolSubsystem.h"
 #include "Item/WorldItem.h"
@@ -144,8 +163,18 @@ AWorldItem* UWorldItemPoolSubsystem::SpawnItemActor(const FSlotStructMaster& Ite
 		// 위치 설정
 		WorldItem->SetActorTransform(Transform, false, nullptr, ETeleportType::TeleportPhysics);
 		// 데이터 주입(AWorldItem::SetItemData가 내부적으로 UpdateAppearance 호출)
-		WorldItem->SetItemData(ItemData);
-
+		//WorldItem->SetItemData(ItemData);
+		// ■ Decay
+		//[S]=====================================================================================
+		// ItemData의 CreationServerTime이 없으면 현재 시각으로 설정
+		FSlotStructMaster ItemDataCopy = ItemData;
+		if (ItemDataCopy.ItemData.CreationServerTime <= 0)
+		{
+			ItemDataCopy.ItemData.CreationServerTime = GetWorld()->GetTimeSeconds();
+		}
+		WorldItem->SetItemData(ItemDataCopy);
+		//[E]=====================================================================================
+		
 		ActiveWorldItems.Add(WorldItem);			// 활성 목록에 추가
 	}
 

--- a/Source/TinySurvivor/Public/Item/WorldItem.h
+++ b/Source/TinySurvivor/Public/Item/WorldItem.h
@@ -1,5 +1,23 @@
 // WorldItem.h
-
+/*
+	===============================================================================
+	[ FILE MODIFICATION NOTICE - DECAY SYSTEM INTEGRATION ]
+	작성자: 양한아
+	날짜: 2025/11/21
+	
+	본 파일에는 '부패(Decay) 시스템'을 통합하기 위한 변경이 포함되어 있습니다.
+	해당 변경들은 모두 아래 표기된 주석 블록 내부에 위치합니다:
+	
+		// ■ Decay
+		//[S]=====================================================================================
+			(Decay 관련 통합 코드)
+		//[E]=====================================================================================
+		
+	위 영역 외의 기존 풀링/스폰/인스턴싱 로직은 변경하지 않았습니다.
+	Decay 시스템만 연동한 최소 변경입니다.
+	후속 작업 시 해당 블록을 참고해주세요.
+	===============================================================================
+*/
 #pragma once
 
 #include "CoreMinimal.h"
@@ -10,6 +28,11 @@
 
 class UStaticMeshComponent;
 class USphereComponent;
+
+// ■ Decay
+//[S]=====================================================================================
+class UDecayManager;
+//[E]=====================================================================================
 
 UCLASS()
 class TINYSURVIVOR_API AWorldItem : public APoolableActorBase
@@ -38,6 +61,27 @@ protected:
 	void OnInteractionEndOverlap(UPrimitiveComponent* OverlappedComponent, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult);
 	
 	void UpdateAppearance();
+	
+	// ■ Decay
+	//[S]=====================================================================================
+	/*
+		DecayManager 캐시
+	*/
+	UPROPERTY()
+	TObjectPtr<UDecayManager> DecayManager;
+	
+	/*
+		부패도 틱 핸들러
+		1초마다 호출됨 (서버 전용)
+	*/
+	UFUNCTION()
+	void OnDecayTick();
+	
+	/*
+		부패물로 전환 처리
+	*/
+	void ConvertToDecayedItem();
+	//[E]=====================================================================================
 
 public:
 	// 풀에서 액터 꺼낼 때
@@ -48,4 +92,10 @@ public:
 	
 	void SetItemData(const FSlotStructMaster& NewItemData);
 	const FSlotStructMaster& GetItemData() const { return ItemData; }
+	
+	// ■ Decay
+	//[S]=====================================================================================
+	virtual void BeginPlay() override;
+	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+	//[E]=====================================================================================
 };


### PR DESCRIPTION
- AWorldItem에 DecayManager 연동 및 ExpirationTime 초기화
- BeginPlay/EndPlay에서 DecayManager Tick 구독/해제
- OnDecayTick 구현: 부패 진행 체크 및 CurrentDecayPercent 갱신
- ConvertToDecayedItem 구현: 부패 완료 시 DecayedItem으로 전환
- WorldItemPoolSubsystem에서 SpawnItemActor 시 CreationServerTime 초기화
- OnRelease 및 풀 반환 시 DecayManager 구독 해제
- 기존 풀링/스폰 로직과 호환되도록 최소 변경