### PR TITLE
docs(GA_ConsumeItem): 소비 로직 관련 주석 보강

### DIFF
--- a/Source/TinySurvivor/Private/GAS/GA/Item/Consumable/GA_ConsumeItem_Base.cpp
+++ b/Source/TinySurvivor/Private/GAS/GA/Item/Consumable/GA_ConsumeItem_Base.cpp
@@ -229,6 +229,11 @@ void UGA_ConsumeItem_Base::Multicast_PlayConsumeMontage_Implementation(UAnimMont
 {
 	UE_LOG(LogConsumeAbility, Log, TEXT("[Multicast] PlayConsumeMontage 호출 시작"));
 	
+	// if (GetAvatarActorFromActorInfo()->HasAuthority())
+	// {// 서버는 재생하지 않음 (중복 재생 방지)
+	// 	return;
+	// }
+	
 	if (!Montage)
 	{
 		UE_LOG(LogConsumeAbility, Warning, TEXT("[Multicast] Montage가 nullptr입니다! 함수 종료"));
@@ -429,10 +434,18 @@ void UGA_ConsumeItem_Base::WaitForConsumption()
 			ConsumeMontage->GetPlayLength(),
 			*GetAvatarActorFromActorInfo()->GetName());
 		
-		// 모든 클라이언트에 몽타주 재생 명령
+		/*
+			Multicast RPC는 클라이언트에서만 호출
+			
+			서버는 이미 Montage Task로 애니메이션을 실행하고 있기 때문에,
+			서버에서 Multicast까지 실행하면 몽타주가 중복 재생되어
+			Ability Task가 Interrupt → Ability 취소가 발생할 수 있다.
+			
+			따라서 클라이언트(Non-Authority)에서만 Multicast RPC를 호출
+		*/
 		if (!GetAvatarActorFromActorInfo()->HasAuthority())
-		{// Multicast는 클라이언트에서만 재생 (Host는 제외)
-			// 모든 클라이언트에게 서버 기준 시작 시간 전달
+		{// 모든 클라이언트에 몽타주 재생 명령
+			// 서버 기준 시작 시간 전달
 			float ServerStartTime = GetWorld()->GetTimeSeconds();
 			Multicast_PlayConsumeMontage(ConsumeMontage, ServerStartTime);
 		}


### PR DESCRIPTION
- 코드 로직 변경 없음 (주석 보강만 포함)
- WaitForConsumption() 내부 로직에 대해 서버/클라이언트 몽타주 실행 방식 및 Multicast 호출 조건을 명확히 설명
- 서버는 PlayMontageAndWait Task로 몽타주를 재생하는 구조임을 명시
- 서버에서 Multicast까지 실행 시 중복 재생으로 Interrupt 발생 가능함을 설명
- 클라이언트(Non-Authority)에서만 Multicast 실행하는 이유 명시
- 전체 네트워크 처리 흐름 이해를 돕는 상세 주석 추가