### PR TITLE
feat(GA_ConsumeItem): 앉은 상태에서도 소비 아이템 어빌리티 실행 가능

### DIFF
--- a/Source/TinySurvivor/Private/GAS/GA/Item/Consumable/GA_ConsumeItem_Base.cpp
+++ b/Source/TinySurvivor/Private/GAS/GA/Item/Consumable/GA_ConsumeItem_Base.cpp
@@ -51,7 +51,7 @@ UGA_ConsumeItem_Base::UGA_ConsumeItem_Base()
 	ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Move_Sprint);
 	ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Move_Roll);
 	ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Move_Jump);
-	ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Move_Crouch);
+	//ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Move_Crouch);
 	//ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Combat_Hit); // 예상
 	
 	// Ability 활성화에 필요한 태그

--- a/Source/TinySurvivor/Private/GAS/GA/Item/Consumable/GA_ConsumeItem_DualEffect_Base.cpp
+++ b/Source/TinySurvivor/Private/GAS/GA/Item/Consumable/GA_ConsumeItem_DualEffect_Base.cpp
@@ -51,7 +51,7 @@ UGA_ConsumeItem_DualEffect_Base::UGA_ConsumeItem_DualEffect_Base()
 	ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Move_Sprint);
 	ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Move_Roll);
 	ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Move_Jump);
-	ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Move_Crouch);
+	//ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Move_Crouch);
 	//ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Combat_Hit); // 예상
 	
 	// Ability 활성화에 필요한 태그


### PR DESCRIPTION
- GA_ConsumeItem_Base.cpp: 앉은 상태 차단 태그(TAG_State_Move_Crouch) 주석 처리
- GA_ConsumeItem_DualEffect_Base.cpp: 동일한 로직 반영
- 앉은 상태에서도 소비 아이템 사용 가능하도록 기획 요청 반영