### PR TITLE
feat(FItemInstance): 구조체에 내구도 필드 및 관련 주석 추가

### DIFF
--- a/Source/TinySurvivor/Public/Item/Runtime/ItemInstance.h
+++ b/Source/TinySurvivor/Public/Item/Runtime/ItemInstance.h
@@ -11,20 +11,26 @@
 	필수 데이터:
 	1. StaticDataID: 정적 데이터 참조용 (ItemDataSubsystem에서 FItemData 조회)
 	2. CreationServerTime: 서버 기준 생성 시각 (부패도 계산용)
+	3. CurrentDurability: 현재 내구도 (도구 등)
 	
 	주요 역할:
 	- 아이템 액터와 인벤토리 슬롯에서 사용
 	- 정적 데이터는 StaticDataID를 통해 ItemDataSubsystem에서 조회
 	- 부패도 계산은 CreationServerTime 기준으로 수행
+	- 내구도 관리:
+		- CurrentDurability < 0: 미초기화 상태 (MaxDurability로 초기화 필요)
+		- CurrentDurability >= 0: 초기화 완료, 사용 시 감소
+		- 0이 되면 아이템 파괴
 	
 	네트워크 고려사항:
 	- 이 구조체는 인벤토리 시스템에서 복제(Replicate)될 예정
 	- 서버에서 생성된 CreationServerTime을 클라이언트도 동일하게 보유
 	- 부패도 계산은 각 클라이언트에서 로컬로 수행 (UI 표시용)
-	- 부패물 전환은 서버에서만 수행
+	- 부패물 전환 및 내구도 감소 처리 등 중요한 게임 로직은 서버에서 수행
+	- 내구도는 인벤토리 슬롯과 함께 자동 복제됨
 	
 	참고:
-	- 내구도, 스택 개수 등의 추가 동적 데이터는 별도 관리
+	- CurrentDurability 외에 스택 개수 등 추가 동적 데이터는 별도 관리
 */
 USTRUCT(BlueprintType)
 struct FItemInstance
@@ -35,11 +41,13 @@ public:
 	FItemInstance()
 		: StaticDataID(0)
 		, CreationServerTime(0.0)
+		, CurrentDurability(-1) // -1 = 미초기화 상태
 	{}
 
-	FItemInstance(int32 InStaticDataID, double InCreationServerTime)
+	FItemInstance(int32 InStaticDataID, double InCreationServerTime, int32 InDurability = -1)
 		: StaticDataID(InStaticDataID)
 		, CreationServerTime(InCreationServerTime)
+		, CurrentDurability(InDurability)
 	{}
 
 	//========================================
@@ -73,6 +81,22 @@ public:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="ItemInstance")
 	double CreationServerTime;
 	
+	/*
+		현재 내구도
+		
+		- -1: 미초기화 (새로 생성된 아이템, MaxDurability로 초기화 필요)
+		- 0 이상: 이미 초기화됨 (기존 내구도 유지)
+		
+		용도:
+		- 도구/무기/방어구의 사용에 따른 내구도 감소
+		- 0이 되면 아이템 파괴
+		
+		네트워크:
+		- 인벤토리 슬롯과 함께 자동 복제
+	*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="ItemInstance|Durability")
+	int32 CurrentDurability;
+	
 	//========================================
 	// Helper Functions
 	//========================================
@@ -80,4 +104,9 @@ public:
 		디버그 정보 출력
 	*/
 	FString ToString() const;
+	
+	/*
+		내구도 초기화 필요 여부 확인
+	*/
+	bool NeedsDurabilityInit() const { return CurrentDurability < 0; }
 };


### PR DESCRIPTION
- FItemInstance 구조체에 CurrentDurability 필드 추가
  - -1: 미초기화, 0 이상: 초기화 완료
  - 사용 시 내구도 감소, 0이 되면 아이템 파괴
- 내구도 초기화 필요 여부를 확인하는 NeedsDurabilityInit() 헬퍼 함수 추가
- 구조체 전체 주석에 내구도 관련 내용 포함
  - 초기화, 감소, 파괴, 네트워크 복제 관련 안내
- 기존 StaticDataID 및 CreationServerTime 관련 주석은 그대로 유지