### PR TITLE
fix(TSInventoryMasterComponent): 방어구 탈착 시 Health가 MaxHealth를 초과하는 문제 수정

### DIFF
--- a/Source/TinySurvivor/Private/Inventory/TSInventoryMasterComponent.cpp
+++ b/Source/TinySurvivor/Private/Inventory/TSInventoryMasterComponent.cpp
@@ -1850,6 +1850,16 @@ void UTSInventoryMasterComponent::UnequipArmor(int32 ArmorSlotIndex)
 			TEXT("방어구 메시 제거 생략: EquippedArmor 포인터가 NULL 또는 유효하지 않음 (SlotIndex=%d)"),
 			ArmorSlotIndex);
 	}
+	
+	// Health 클램핑
+	UTSAttributeSet* AttrSet = const_cast<UTSAttributeSet*>(ASC->GetSet<UTSAttributeSet>());
+	if (AttrSet && AttrSet->GetHealth() > AttrSet->GetMaxHealth())
+	{
+		AttrSet->SetHealth(AttrSet->GetMaxHealth());
+		UE_LOG(LogInventoryComp, Warning,
+			TEXT("방어구 탈착 후 Health 클램핑: %.1f → %.1f"),
+			AttrSet->GetHealth(), AttrSet->GetMaxHealth());
+	}
 }
 
 void UTSInventoryMasterComponent::OnArmorHitEvent(const FGameplayEventData* Payload)


### PR DESCRIPTION
- UnequipArmor()에서 방어구 탈착 후 Health가 MaxHealth를 초과하는 문제 수정
- Health > MaxHealth 발생 시 Health를 자동 클램핑하는 로직 추가
- 스탯 일관성 유지 및 UI/전투 계산 오류 예방
- TSInventoryMasterComponent.cpp 내 탈착 처리 안정성 개선