### PR TITLE
chore(log): 디버그 로그 배포 빌드 최적화

### DIFF
--- a/Source/TinySurvivor/Private/Building/System/BuildingRecipeDataSubsystem.cpp
+++ b/Source/TinySurvivor/Private/Building/System/BuildingRecipeDataSubsystem.cpp
@@ -31,6 +31,7 @@ void UBuildingRecipeDataSubsystem::Initialize(FSubsystemCollectionBase& Collecti
 {
 	Super::Initialize(Collection);
 	
+#if UE_BUILD_DEBUG || UE_BUILD_DEVELOPMENT
 	UE_LOG(LogBuildingRecipeDataSubsystem, Log, TEXT("BuildingRecipeDataSubsystem Initialized"));
 	
 	// 네트워크 환경 확인 (디버그용)
@@ -43,6 +44,7 @@ void UBuildingRecipeDataSubsystem::Initialize(FSubsystemCollectionBase& Collecti
 			NetMode == NM_ListenServer ? TEXT("ListenServer") :
 			NetMode == NM_Client ? TEXT("Client") : TEXT("Unknown"));
 	}
+#endif
 	
 	// Project Settings에서 자동 로드
 	const UBuildingRecipeSystemSettings* Settings = UBuildingRecipeSystemSettings::Get();
@@ -73,7 +75,9 @@ void UBuildingRecipeDataSubsystem::Initialize(FSubsystemCollectionBase& Collecti
 
 void UBuildingRecipeDataSubsystem::Deinitialize()
 {
+#if UE_BUILD_DEBUG || UE_BUILD_DEVELOPMENT
 	UE_LOG(LogBuildingRecipeDataSubsystem, Log, TEXT("BuildingRecipeDataSubsystem Deinitialized"));
+#endif
 	
 	ClearAllCaches();
 	TableAsset = nullptr;
@@ -164,9 +168,8 @@ bool UBuildingRecipeDataSubsystem::InitializeFromAsset(UBuildingRecipeTableAsset
 	UE_LOG(LogBuildingRecipeDataSubsystem, Log, TEXT("- Recipes: %d"), BuildingRecipeDataCache.Num());
 	
 	// 에디터에서만 자동 테스트 실행
-#if WITH_EDITOR
+
 	RunInitializationTests();
-#endif
 #endif
 	
 	return true;
@@ -314,6 +317,7 @@ void UBuildingRecipeDataSubsystem::GetCacheStatistics(int32& OutRecipeCount) con
 // 캐시 디버그 정보를 콘솔에 출력
 void UBuildingRecipeDataSubsystem::PrintCacheDebugInfo() const
 {
+#if UE_BUILD_DEBUG || UE_BUILD_DEVELOPMENT
 	UE_LOG(LogBuildingRecipeDataSubsystem, Display, TEXT("=== BuildingRecipeDataSubsystem Cache Statistics ==="));
 	UE_LOG(LogBuildingRecipeDataSubsystem, Display, TEXT("Initialized: %s"), bIsInitialized ? TEXT("Yes") : TEXT("No"));
 	UE_LOG(LogBuildingRecipeDataSubsystem, Display, TEXT("Recipes Cached: %d"), BuildingRecipeDataCache.Num());
@@ -347,6 +351,7 @@ void UBuildingRecipeDataSubsystem::PrintCacheDebugInfo() const
 	}
 	
 	UE_LOG(LogBuildingRecipeDataSubsystem, Display, TEXT("====================================================="));
+#endif
 }
 
 void UBuildingRecipeDataSubsystem::PrintRecipeDebugInfo(int32 RecipeID) const
@@ -365,12 +370,13 @@ void UBuildingRecipeDataSubsystem::PrintRecipeDebugInfo(int32 RecipeID) const
 		return;
 	}
 	
+#if UE_BUILD_DEBUG || UE_BUILD_DEVELOPMENT
 	UE_LOG(LogBuildingRecipeDataSubsystem, Display, TEXT("\n========== Debug Info for RecipeID %d =========="), RecipeID);
 	FoundData->PrintDebugInfo();
 	UE_LOG(LogBuildingRecipeDataSubsystem, Display, TEXT("====================================================\n"));
+#endif
 }
 
-#if WITH_EDITOR
 // 캐시를 새로고침 (TableAsset 기반으로 다시 로드)
 void UBuildingRecipeDataSubsystem::RefreshCache()
 {
@@ -387,13 +393,16 @@ void UBuildingRecipeDataSubsystem::RefreshCache()
 	ClearAllCaches();
 	CacheBuildingRecipeData();
 	
+#if UE_BUILD_DEBUG || UE_BUILD_DEVELOPMENT
 	UE_LOG(LogBuildingRecipeDataSubsystem, Log, TEXT("캐시 새로고침 완료"));
 	// 새로고침 후 캐시 상태 디버그 출력
 	PrintCacheDebugInfo();
+#endif
 }
 
 void UBuildingRecipeDataSubsystem::RunInitializationTests()
 {
+#if UE_BUILD_DEBUG || UE_BUILD_DEVELOPMENT
 	UE_LOG(LogBuildingRecipeDataSubsystem, Display, TEXT("========================================"));
 	UE_LOG(LogBuildingRecipeDataSubsystem, Display, TEXT("BuildingRecipeDataSubsystem 초기화 테스트 시작"));
 	UE_LOG(LogBuildingRecipeDataSubsystem, Display, TEXT("========================================"));
@@ -499,8 +508,8 @@ void UBuildingRecipeDataSubsystem::RunInitializationTests()
 	UE_LOG(LogBuildingRecipeDataSubsystem, Display, TEXT("========================================"));
 	UE_LOG(LogBuildingRecipeDataSubsystem, Display, TEXT("테스트 완료"));
 	UE_LOG(LogBuildingRecipeDataSubsystem, Display, TEXT("========================================"));
-}
 #endif
+}
 #pragma endregion
 
 #pragma region InternalCachingFunctions
@@ -536,7 +545,9 @@ void UBuildingRecipeDataSubsystem::CacheBuildingRecipeData()
 		}
 	}
 	
+#if UE_BUILD_DEBUG || UE_BUILD_DEVELOPMENT
 	UE_LOG(LogBuildingRecipeDataSubsystem, Log, TEXT("총 %d개의 건축물 레시피 캐싱 완료"), BuildingRecipeDataCache.Num());
+#endif
 }
 
 // 모든 캐시 데이터를 초기화

--- a/Source/TinySurvivor/Private/Crafting/System/CraftingDataSubsystem.cpp
+++ b/Source/TinySurvivor/Private/Crafting/System/CraftingDataSubsystem.cpp
@@ -30,6 +30,7 @@ void UCraftingDataSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 {
 	Super::Initialize(Collection);
 	
+#if UE_BUILD_DEBUG || UE_BUILD_DEVELOPMENT
 	UE_LOG(LogCraftingDataSubsystem, Log, TEXT("CraftingDataSubsystem Initialized"));
 	
 	// 네트워크 환경 확인 (디버그용)
@@ -42,6 +43,7 @@ void UCraftingDataSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 			NetMode == NM_ListenServer ? TEXT("ListenServer") :
 			NetMode == NM_Client ? TEXT("Client") : TEXT("Unknown"));
 	}
+#endif
 	
 	// Project Settings에서 자동 로드
 	const UCraftingSystemSettings* Settings = UCraftingSystemSettings::Get();
@@ -72,7 +74,9 @@ void UCraftingDataSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 
 void UCraftingDataSubsystem::Deinitialize()
 {
+#if UE_BUILD_DEBUG || UE_BUILD_DEVELOPMENT
 	UE_LOG(LogCraftingDataSubsystem, Log, TEXT("CraftingDataSubsystem Deinitialized"));
+#endif
 	
 	ClearAllCaches();
 	TableAsset = nullptr;
@@ -163,9 +167,7 @@ bool UCraftingDataSubsystem::InitializeFromAsset(UCraftingTableAsset* InTableAss
 	UE_LOG(LogCraftingDataSubsystem, Log, TEXT("- Recipes: %d"), CraftingDataCache.Num());
 	
 	// 에디터에서만 자동 테스트 실행
-#if WITH_EDITOR
 	RunInitializationTests();
-#endif
 #endif
 	
 	return true;
@@ -377,6 +379,7 @@ void UCraftingDataSubsystem::GetCacheStatistics(int32& OutRecipeCount) const
 // 캐시 디버그 정보를 콘솔에 출력
 void UCraftingDataSubsystem::PrintCacheDebugInfo() const
 {
+#if UE_BUILD_DEBUG || UE_BUILD_DEVELOPMENT
 	UE_LOG(LogCraftingDataSubsystem, Display, TEXT("=== CraftingDataSubsystem Cache Statistics ==="));
 	UE_LOG(LogCraftingDataSubsystem, Display, TEXT("Initialized: %s"), bIsInitialized ? TEXT("Yes") : TEXT("No"));
 	UE_LOG(LogCraftingDataSubsystem, Display, TEXT("Recipes Cached: %d"), CraftingDataCache.Num());
@@ -467,6 +470,7 @@ void UCraftingDataSubsystem::PrintCacheDebugInfo() const
 	// }
 	
 	UE_LOG(LogCraftingDataSubsystem, Display, TEXT("==============================================="));
+#endif
 }
 
 void UCraftingDataSubsystem::PrintRecipeDebugInfo(int32 RecipeID) const
@@ -485,12 +489,13 @@ void UCraftingDataSubsystem::PrintRecipeDebugInfo(int32 RecipeID) const
 		return;
 	}
 	
+#if UE_BUILD_DEBUG || UE_BUILD_DEVELOPMENT
 	UE_LOG(LogCraftingDataSubsystem, Display, TEXT("\n========== Debug Info for RecipeID %d =========="), RecipeID);
 	FoundData->PrintDebugInfo();
 	UE_LOG(LogCraftingDataSubsystem, Display, TEXT("====================================================\n"));
+#endif
 }
 
-#if WITH_EDITOR
 // 캐시를 새로고침 (TableAsset 기반으로 다시 로드)
 void UCraftingDataSubsystem::RefreshCache()
 {
@@ -507,13 +512,16 @@ void UCraftingDataSubsystem::RefreshCache()
 	ClearAllCaches();
 	CacheCraftingData();
 	
+#if UE_BUILD_DEBUG || UE_BUILD_DEVELOPMENT
 	UE_LOG(LogCraftingDataSubsystem, Log, TEXT("캐시 새로고침 완료"));
 	// 새로고침 후 캐시 상태 디버그 출력
 	PrintCacheDebugInfo();
+#endif
 }
 
 void UCraftingDataSubsystem::RunInitializationTests()
 {
+#if UE_BUILD_DEBUG || UE_BUILD_DEVELOPMENT
 	UE_LOG(LogCraftingDataSubsystem, Display, TEXT("========================================"));
 	UE_LOG(LogCraftingDataSubsystem, Display, TEXT("CraftingDataSubsystem 초기화 테스트 시작"));
 	UE_LOG(LogCraftingDataSubsystem, Display, TEXT("========================================"));
@@ -625,8 +633,8 @@ void UCraftingDataSubsystem::RunInitializationTests()
 	UE_LOG(LogCraftingDataSubsystem, Display, TEXT("========================================"));
 	UE_LOG(LogCraftingDataSubsystem, Display, TEXT("테스트 완료"));
 	UE_LOG(LogCraftingDataSubsystem, Display, TEXT("========================================"));
-}
 #endif
+}
 #pragma endregion
 
 #pragma region InternalCachingFunctions
@@ -663,7 +671,9 @@ void UCraftingDataSubsystem::CacheCraftingData()
 		}
 	}
 	
+#if UE_BUILD_DEBUG || UE_BUILD_DEVELOPMENT
 	UE_LOG(LogCraftingDataSubsystem, Log, TEXT("총 %d개의 제작 레시피 캐싱 완료"), CraftingDataCache.Num());
+#endif
 }
 
 // 모든 캐시 데이터를 초기화

--- a/Source/TinySurvivor/Private/Item/System/ItemDataSubsystem.cpp
+++ b/Source/TinySurvivor/Private/Item/System/ItemDataSubsystem.cpp
@@ -570,6 +570,7 @@ void UItemDataSubsystem::PrintItemDebugInfo(int32 ItemID) const
 		UE_LOG(LogItemDataSubsystem, Warning, TEXT("[PrintItemDebugInfo] ItemID %d not found in ItemDataCache."), ItemID);
 		return;
 	}
+	
 #if UE_BUILD_DEBUG || UE_BUILD_DEVELOPMENT
 	UE_LOG(LogItemDataSubsystem, Display, TEXT("\n========== Debug Info for ItemID %d =========="), ItemID);
 	FoundData->PrintDebugInfo();
@@ -592,6 +593,7 @@ void UItemDataSubsystem::PrintBuildingDebugInfo(int32 BuildingID) const
 		UE_LOG(LogItemDataSubsystem, Warning, TEXT("[PrintBuildingDebugInfo] BuildingID %d not found in BuildingDataCache."), BuildingID);
 		return;
 	}
+	
 #if UE_BUILD_DEBUG || UE_BUILD_DEVELOPMENT
 	UE_LOG(LogItemDataSubsystem, Display, TEXT("\n========== Debug Info for BuildingID %d =========="), BuildingID);
 	FoundData->PrintDebugInfo();
@@ -614,6 +616,7 @@ void UItemDataSubsystem::PrintResourceDebugInfo(int32 ResourceID) const
 		UE_LOG(LogItemDataSubsystem, Warning, TEXT("[PrintResourceDebugInfo] ResourceID %d not found in ResourceDataCache."), ResourceID);
 		return;
 	}
+	
 #if UE_BUILD_DEBUG || UE_BUILD_DEVELOPMENT
 	UE_LOG(LogItemDataSubsystem, Display, TEXT("\n========== Debug Info for ResourceID %d =========="), ResourceID);
 	FoundData->PrintDebugInfo();
@@ -639,9 +642,11 @@ void UItemDataSubsystem::RefreshCache()
 	CacheBuildingData();
 	CacheResourceData();
 	
+#if UE_BUILD_DEBUG || UE_BUILD_DEVELOPMENT
 	UE_LOG(LogItemDataSubsystem, Log, TEXT("캐시 새로고침 완료"));
 	// 새로고침 후 캐시 상태 디버그 출력
 	PrintCacheDebugInfo();
+#endif
 }
 
 void UItemDataSubsystem::RunInitializationTests()
@@ -796,6 +801,7 @@ void UItemDataSubsystem::CacheItemData()
 				RowData ? RowData->ItemID : -1);
 		}
 	}
+	
 #if UE_BUILD_DEBUG || UE_BUILD_DEVELOPMENT
 	UE_LOG(LogItemDataSubsystem, Log, TEXT("총 %d개의 아이템 캐싱 완료"), ItemDataCache.Num());
 #endif
@@ -829,6 +835,7 @@ void UItemDataSubsystem::CacheBuildingData()
 				RowData ? RowData->BuildingID : -1);
 		}
 	}
+	
 #if UE_BUILD_DEBUG || UE_BUILD_DEVELOPMENT
 	UE_LOG(LogItemDataSubsystem, Log, TEXT("총 %d개의 건축물 캐싱 완료"), BuildingDataCache.Num());
 #endif
@@ -862,6 +869,7 @@ void UItemDataSubsystem::CacheResourceData()
 				RowData ? RowData->ResourceID : -1);
 		}
 	}
+	
 #if UE_BUILD_DEBUG || UE_BUILD_DEVELOPMENT
 	UE_LOG(LogItemDataSubsystem, Log, TEXT("총 %d개의 자원 캐싱 완료"), ResourceDataCache.Num());
 #endif

--- a/Source/TinySurvivor/Public/Building/System/BuildingRecipeDataSubsystem.h
+++ b/Source/TinySurvivor/Public/Building/System/BuildingRecipeDataSubsystem.h
@@ -226,20 +226,18 @@ public:
 	UFUNCTION(BlueprintCallable, Category="BuildingRecipeData|Debug")
 	void PrintRecipeDebugInfo(int32 RecipeID) const;
 	
-#if WITH_EDITOR
 	/*
-		에디터 전용: 캐시 리프레시
+		캐시 리프레시
 		데이터 테이블 변경 후 에디터에서 실시간 반영용
 	*/
 	UFUNCTION(CallInEditor, Category="BuildingRecipeData|Editor")
 	void RefreshCache();
 	
 	/*
-		에디터 전용: 초기화 후 자동 테스트
+		초기화 후 자동 테스트
 		InitializeFromAsset() 완료 후 호출됨
 	*/
 	void RunInitializationTests();
-#endif
 #pragma endregion
 	
 #pragma region InternalCachingFunctions

--- a/Source/TinySurvivor/Public/Crafting/System/CraftingDataSubsystem.h
+++ b/Source/TinySurvivor/Public/Crafting/System/CraftingDataSubsystem.h
@@ -255,20 +255,18 @@ public:
 	UFUNCTION(BlueprintCallable, Category="CraftingData|Debug")
 	void PrintRecipeDebugInfo(int32 RecipeID) const;
 	
-#if WITH_EDITOR
 	/*
-		에디터 전용: 캐시 리프레시
+		캐시 리프레시
 		데이터 테이블 변경 후 에디터에서 실시간 반영용
 	*/
 	UFUNCTION(CallInEditor, Category="CraftingData|Editor")
 	void RefreshCache();
 	
 	/*
-		에디터 전용: 초기화 후 자동 테스트
+		초기화 후 자동 테스트
 		InitializeFromAsset() 완료 후 호출됨
 	*/
 	void RunInitializationTests();
-#endif
 #pragma endregion
 
 #pragma region InternalCachingFunctions

--- a/Source/TinySurvivor/Public/Item/System/ItemDataSubsystem.h
+++ b/Source/TinySurvivor/Public/Item/System/ItemDataSubsystem.h
@@ -318,20 +318,18 @@ public:
 	UFUNCTION(BlueprintCallable, Category="ItemData|Debug")
 	void PrintResourceDebugInfo(int32 ResourceID) const;
 	
-#if WITH_EDITOR
 	/*
-		에디터 전용: 캐시 리프레시
+		캐시 리프레시
 		데이터 테이블 변경 후 에디터에서 실시간 반영용
 	*/
 	UFUNCTION(CallInEditor, Category="ItemData|Editor")
 	void RefreshCache();
 	
 	/*
-		에디터 전용: 초기화 후 자동 테스트
+		초기화 후 자동 테스트
 		InitializeFromAsset() 완료 후 호출됨
 	*/
 	void RunInitializationTests();
-#endif
 #pragma endregion
 
 #pragma region InternalCachingFunctions


### PR DESCRIPTION
- 적용: ItemDataSubsystem / CraftingDataSubsystem / BuildingRecipeDataSubsystem (h/cpp) - 디버그 로그를 UE_BUILD_DEBUG/DEVELOPMENT 매크로로 감싸서 배포 빌드 최적화 - 배포 빌드에서 불필요한 로그 제거로 성능 및 패키지 용량 개선
- 헤더 파일에서는 WITH_EDITOR 매크로 제거