### PR TITLE
fix(TSInventoryMasterComponent): 소모품 아이템 연타 시 중복 소비 방지

### DIFF
--- a/Source/TinySurvivor/Public/Inventory/TSInventoryMasterComponent.h
+++ b/Source/TinySurvivor/Public/Inventory/TSInventoryMasterComponent.h
@@ -60,6 +60,7 @@ public:
 
 protected:
 	virtual void BeginPlay() override;
+	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
 public:
 	// ========================================
@@ -350,6 +351,30 @@ protected:
 	
 	UPROPERTY(EditDefaultsOnly, Category = "Armor Stats")
 	TSubclassOf<UGameplayEffect> ArmorEffectStatEffectClass; // GE_ArmorEffectStats_Base
+#pragma endregion
+	
+#pragma region ConsumableAbility
+private:
+	// 현재 활성화된 소모품 Ability의 SpecHandle
+	FGameplayAbilitySpecHandle ActiveConsumableAbilityHandle;
+	
+	// Timer 취소용 핸들
+	FTimerHandle ConsumableAbilityTriggerTimer;
+	
+	// 소모품 Ability 관련 리소스 정리
+	void ClearConsumableAbilityResources();
+	
+	/*
+		소모품 Ability를 부여하고 Trigger 예약
+		@param ItemInfo 아이템 정보
+		@param SlotIndex 슬롯 인덱스
+		@param ASC AbilitySystemComponent
+		@return 성공 여부
+	*/
+	bool GrantAndScheduleConsumableAbility(
+		const FItemData& ItemInfo, 
+		int32 SlotIndex, 
+		UAbilitySystemComponent* ASC);
 #pragma endregion
 	
 private:


### PR DESCRIPTION
## Description
우클릭 연타 시 이전 소모품 Ability가 취소되지 않고 계속 진행되어
연타 중에 아이템이 중복 소비되는 문제 해결 및 코드 구조 개선

## Problem
- 우클릭 연타 시 몽타주는 재시작하지만 GA는 계속 진행되어 중복 소비
- Timer/Ability Spec 메모리 누수 및 Lambda 댕글링 포인터 위험
- 슬롯 변경 시에도 이전 Timer가 남아있어 잘못된 아이템 소비 가능

## Solution

### 추가된 내용
**TSInventoryMasterComponent.h**
- `FGameplayAbilitySpecHandle ActiveConsumableAbilityHandle`: 현재 활성화된 소모품 Ability SpecHandle 추적
- `FTimerHandle ConsumableAbilityTriggerTimer`: Ability Trigger Timer 핸들 (취소용)
- `EndPlay()`: 컴포넌트 종료 시 리소스 정리
- `ClearConsumableAbilityResources()`: 소모품 Ability 관련 리소스 정리 헬퍼 함수
- `GrantAndScheduleConsumableAbility()`: 소모품 Ability 부여 및 Trigger 예약 함수

### 변경된 내용
**TSInventoryMasterComponent.cpp**

1. **ServerActivateHotkeySlot_Implementation()**
   - 슬롯 변경 시 `ClearConsumableAbilityResources()` 호출 추가
   - 예약된 Ability Trigger Timer 취소로 잘못된 아이템 소비 방지

2. **Internal_UseItem() - 소모품 처리 로직 개선**
   - 기존 인라인 Ability 발동 로직(120줄) → `GrantAndScheduleConsumableAbility()` 호출(3줄)로 단순화
   - 소모품 처리 전 `ClearConsumableAbilityResources()` 호출로 이전 리소스 정리

3. **GrantAndScheduleConsumableAbility() - 신규 함수**
   - Ability Spec 생성 및 부여
   - `ActiveConsumableAbilityHandle`에 SpecHandle 저장
   - TWeakObjectPtr로 안전한 Lambda 캡처
   - `ConsumableAbilityTriggerTimer`로 관리되는 Timer 생성
   - Trigger 시점 SpecHandle 재검증으로 취소된 Ability 활성화 방지

4. **ClearConsumableAbilityResources() - 신규 헬퍼 함수**
   - Timer 취소 및 무효화
   - 활성 Ability 취소 (`CancelAbilityHandle`)
   - Ability Spec 메모리 해제 (`ClearAbility`)
   - 핸들 무효화로 중복 처리 방지

5. **EndPlay()**
   - 컴포넌트 종료 시 `ClearConsumableAbilityResources()` 호출
   - BeginDestroy 타이밍 이슈 해결 (GetWorld() nullptr 방지)

## Technical Details
- 연타 방지: 이전 Ability/Timer 완전 정리 → 새 Ability 시작 → 마지막만 소비
- 메모리 안전: TWeakObjectPtr로 Lambda 크래시 방지, ClearAbility로 Spec 누수 방지
- 코드 품질: 120줄 인라인 로직 → 별도 함수로 추출하여 가독성/재사용성 향상

## Testing
- 정상 소비: 우클릭 → 1.7초 대기 → 소비 완료
- 연타 (0.5초 간격 × 3회): 마지막만 소비
- 슬롯 변경 중: 이전 아이템 소비 안 됨
- 컴포넌트 파괴 중: 크래시 없이 안전 종료