### PR TITLE
feat(아이템 소비): 소비 로직에 상태 추가 및 몽타주에서 Cancel 태그 추가

### DIFF
--- a/Source/TinySurvivor/Private/GAS/GA/Item/Consumable/GA_ConsumeItem_Base.cpp
+++ b/Source/TinySurvivor/Private/GAS/GA/Item/Consumable/GA_ConsumeItem_Base.cpp
@@ -60,8 +60,13 @@ UGA_ConsumeItem_Base::UGA_ConsumeItem_Base()
 	ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Move_Sprint);
 	ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Move_Roll);
 	ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Move_Jump);
-	//ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Move_Crouch);
+	ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Status_Attack);
+	ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Status_Downed);
+	ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Status_Dead);
+	ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Status_Rescuing);
+	ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Status_PickUpItem);
 	//ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Combat_Hit); // 예상
+	//ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Move_Crouch); // 변경: 앉음 상태는 먹을 수 있음
 	
 	// Ability 활성화에 필요한 태그
 	// ActivationRequiredTags.AddTag(...);
@@ -118,6 +123,11 @@ void UGA_ConsumeItem_Base::ActivateAbility(
 			AbilityTags::TAG_State_Move_Roll,
 			AbilityTags::TAG_State_Move_Jump,
 			AbilityTags::TAG_State_Move_Climb,
+			AbilityTags::TAG_State_Status_Attack,
+			AbilityTags::TAG_State_Status_Downed,
+			AbilityTags::TAG_State_Status_Dead,
+			AbilityTags::TAG_State_Status_Rescuing,
+			AbilityTags::TAG_State_Status_PickUpItem,
 			// TODO: 피격 태그 생성되면 추가
 			//AbilityTags::TAG_State_Combat_Hit (예상)
 		};

--- a/Source/TinySurvivor/Private/GAS/GA/Item/Consumable/GA_ConsumeItem_DualEffect_Base.cpp
+++ b/Source/TinySurvivor/Private/GAS/GA/Item/Consumable/GA_ConsumeItem_DualEffect_Base.cpp
@@ -60,8 +60,13 @@ UGA_ConsumeItem_DualEffect_Base::UGA_ConsumeItem_DualEffect_Base()
 	ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Move_Sprint);
 	ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Move_Roll);
 	ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Move_Jump);
-	//ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Move_Crouch);
+	ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Status_Attack);
+	ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Status_Downed);
+	ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Status_Dead);
+	ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Status_Rescuing);
+	ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Status_PickUpItem);
 	//ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Combat_Hit); // 예상
+	//ActivationBlockedTags.AddTag(AbilityTags::TAG_State_Move_Crouch); // 변경: 앉음 상태는 먹을 수 있음
 	
 	// Ability 활성화에 필요한 태그
 	// ActivationRequiredTags.AddTag(...);
@@ -110,22 +115,29 @@ void UGA_ConsumeItem_DualEffect_Base::ActivateAbility(
 	// 1. Cancel 태그 이벤트 구독
 	//=======================================================================
 	UAbilitySystemComponent* ASC = ActorInfo->AbilitySystemComponent.Get();
-	
-	CancelTags = {
-		AbilityTags::TAG_State_Move_WASD,
-		AbilityTags::TAG_State_Move_Sprint,
-		AbilityTags::TAG_State_Move_Crouch,
-		AbilityTags::TAG_State_Move_Roll,
-		AbilityTags::TAG_State_Move_Jump,
-		AbilityTags::TAG_State_Move_Climb,
-		// TODO: 피격 태그 생성되면 추가
-		//AbilityTags::TAG_State_Combat_Hit (예상)
-	};
-	
-	for (const FGameplayTag& Tag : CancelTags)
-	{// 태그가 새로 추가되면 OnCancelTagChanged 호출
-		ASC->RegisterGameplayTagEvent(Tag, EGameplayTagEventType::NewOrRemoved)
-				.AddUObject(this, &UGA_ConsumeItem_DualEffect_Base::OnCancelTagChanged);
+	if (ASC)
+	{
+		CancelTags = {
+			AbilityTags::TAG_State_Move_WASD,
+			AbilityTags::TAG_State_Move_Sprint,
+			AbilityTags::TAG_State_Move_Crouch,
+			AbilityTags::TAG_State_Move_Roll,
+			AbilityTags::TAG_State_Move_Jump,
+			AbilityTags::TAG_State_Move_Climb,
+			AbilityTags::TAG_State_Status_Attack,
+			AbilityTags::TAG_State_Status_Downed,
+			AbilityTags::TAG_State_Status_Dead,
+			AbilityTags::TAG_State_Status_Rescuing,
+			AbilityTags::TAG_State_Status_PickUpItem,
+			// TODO: 피격 태그 생성되면 추가
+			//AbilityTags::TAG_State_Combat_Hit (예상)
+		};
+		
+		for (const FGameplayTag& Tag : CancelTags)
+		{// 태그가 새로 추가되면 OnCancelTagChanged 호출
+			ASC->RegisterGameplayTagEvent(Tag, EGameplayTagEventType::NewOrRemoved)
+					.AddUObject(this, &UGA_ConsumeItem_DualEffect_Base::OnCancelTagChanged);
+		}
 	}
 	
 	//=======================================================================

--- a/Source/TinySurvivor/Private/Inventory/TSInventoryMasterComponent.cpp
+++ b/Source/TinySurvivor/Private/Inventory/TSInventoryMasterComponent.cpp
@@ -541,6 +541,11 @@ void UTSInventoryMasterComponent::Internal_UseItem(int32 SlotIndex)
 		CancelTags.AddTag(AbilityTags::TAG_State_Move_Roll);
 		CancelTags.AddTag(AbilityTags::TAG_State_Move_Jump);
 		CancelTags.AddTag(AbilityTags::TAG_State_Move_Climb);
+		CancelTags.AddTag(AbilityTags::TAG_State_Status_Attack);
+		CancelTags.AddTag(AbilityTags::TAG_State_Status_Downed);
+		CancelTags.AddTag(AbilityTags::TAG_State_Status_Dead);
+		CancelTags.AddTag(AbilityTags::TAG_State_Status_Rescuing);
+		CancelTags.AddTag(AbilityTags::TAG_State_Status_PickUpItem);
 		//CancelTags.AddTag(AbilityTags::TAG_State_Move_Crouch);
 		// TODO: 피격 태그 추가
 		// CancelTags.AddTag(AbilityTags::TAG_State_Combat_Hit); // 예상


### PR DESCRIPTION
- 소비 로직 수정
- 소비 Ability의 활성화 차단 및 Cancel 태그 이벤트에 상태 추가
- 소비 몽타주에서 Cancel 태그 체크 시 상태 추가
- 추가된 상태:
   - TAG_State_Status_Attack
   - TAG_State_Status_Downed
   - TAG_State_Status_Dead
   - TAG_State_Status_Rescuing
   - TAG_State_Status_PickUpItem