### PR TITLE
fix(Building): 프리뷰 메시 색상 업데이트 안되는 버그 수정

### DIFF
--- a/Source/TinySurvivor/Public/Building/TSBuildingComponent.h
+++ b/Source/TinySurvivor/Public/Building/TSBuildingComponent.h
@@ -82,8 +82,6 @@ private:
 	UFUNCTION()
 	void OnRep_IsBuildingMode();
 	UPROPERTY(Replicated)
-	bool bCanPlace = false;
-	UPROPERTY(Replicated)
 	int32 CurrentRecipeID = 0;
 	UPROPERTY(Replicated)
 	int32 CurrentBuildingDataID = 0;
@@ -102,6 +100,7 @@ private:
 	UPROPERTY()
 	TArray<TObjectPtr<UMaterialInstanceDynamic>> CachedDynamicMaterials;
 
+	bool bCanPlace = false;
 	bool bLastCanPlace = false;
 
 	mutable UItemDataSubsystem* CachedIDS = nullptr;


### PR DESCRIPTION
빌딩 설치 및 프리뷰 메시 갱신 로직 최적화.
- `bCanPlace` 필드를 Replication에서 제외하고 로컬 상태로 변경
- UpdatePreviewMesh(): CreatePreviewMesh에서 캐싱한 머티리얼 사용하도록 수정
- CreatePreviewMesh(): `CachedDynamicMaterials.Empty()` 호출 추가로 기존 머티리얼 초기화 처리
- 반복문 최적화 및 불필요한 코드 정리