### PR TITLE
fix(GC_ElectricShock_Material): USoundCue 타입 인식 문제 방지

### DIFF
--- a/Source/TinySurvivor/Public/GAS/GC/Gimmick/GC_ElectricShock_Material.h
+++ b/Source/TinySurvivor/Public/GAS/GC/Gimmick/GC_ElectricShock_Material.h
@@ -3,6 +3,7 @@
 
 #include "CoreMinimal.h"
 #include "GameplayCueNotify_Actor.h"
+#include "Sound/SoundCue.h"
 #include "GC_ElectricShock_Material.generated.h"
 
 /*


### PR DESCRIPTION
- Cpp에만 포함된 헤더를 헤더파일에도 기재
- #include "Sound/SoundCue.h" 추가
- USoundCue 타입 컴파일 오류 가능성 해결
- 컴파일 호환성 향상