### PR TITLE
fix(Character): 라인트레이스 타겟 판별 로직 수정

### DIFF
--- a/Source/TinySurvivor/Private/Character/TSCharacter.cpp
+++ b/Source/TinySurvivor/Private/Character/TSCharacter.cpp
@@ -1375,8 +1375,8 @@ void ATSCharacter::LineTrace()
 	FCollisionQueryParams Params;
 	Params.AddIgnoredActor(this);
 	
-	// GetWorld()->LineTraceSingleByChannel(HitResult, TraceStart, TraceEnd, TraceChannel);
-	if (!GetWorld()->LineTraceSingleByChannel(HitResult, TraceStart, TraceEnd, ECC_Pawn, Params))
+	bool bHitPawn = GetWorld()->LineTraceSingleByChannel(HitResult, TraceStart, TraceEnd, ECC_Pawn, Params);	
+	if (!bHitPawn || (HitResult.GetActor() && !HitResult.GetActor()->IsA(ATSCharacter::StaticClass())))
 	{
 		GetWorld()->LineTraceSingleByChannel(HitResult, TraceStart, TraceEnd, TraceChannel, Params);
 	}


### PR DESCRIPTION

기존 로직이 지형을 검출해 아이템 감지가 제대로 안되는 버그 수정
- LineTraceSingleByChannel 호출 결과를 bHitPawn 변수로 분리
- HitResult의 Actor가 ATSCharacter 유형인지 검사하는 조건 추가