### PR TITLE
feat(GimmickSystem): 감전 머티리얼 개선과 독 영역 오버레이 적용 방식 수정 및 디버깅 정리

### DIFF
--- a/Content/Blueprints/GC/Gimmick/GC_Poison_Material.uasset
+++ b/Content/Blueprints/GC/Gimmick/GC_Poison_Material.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a9b882976b6a168ffcd473785bc3593d8a6b277b8e2a61f2f0b1194f4ce06b16
-size 24566
+oid sha256:09128548e70a7fcf16d1e8b845d1d0e120ede59a775a9a9f9741bb1a3cf37278
+size 24296

--- a/Content/Blueprints/Gimmick/BP_Zone_ElectricShock.uasset
+++ b/Content/Blueprints/Gimmick/BP_Zone_ElectricShock.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b58cbba8e0e7386f1f970ccd47dc492100cbcba104e2e6785892f8c63624f302
-size 26588
+oid sha256:fab1222adaf205ec0b789369ccaf7131f46c0cbe631cc9a1dfb965439c6d6d67
+size 26597

--- a/Content/Blueprints/Gimmick/BP_Zone_Poison.uasset
+++ b/Content/Blueprints/Gimmick/BP_Zone_Poison.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9c0c5e166a2059d8da056528caf41a37fb1f92044c5668580e4930084e1acdad
-size 26881
+oid sha256:b5236cce3a594920b7ae445fda7561c875cbff4b59a914c00e27840f7cd22b09
+size 26842

--- a/Content/Blueprints/Gimmick/BP_Zone_SpeedDecrease.uasset
+++ b/Content/Blueprints/Gimmick/BP_Zone_SpeedDecrease.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2217510e0f0601fb9533cc209b7d7da6f290cb7dff756500f0d9ff21d52341bb
-size 26281
+oid sha256:bafb24435de0af7a516442865c3c9a4cf661a5d8ebc52b5a01c518b5b138d7b9
+size 25850

--- a/Content/Blueprints/Gimmick/BP_Zone_SpeedIncrease.uasset
+++ b/Content/Blueprints/Gimmick/BP_Zone_SpeedIncrease.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:250bc04eb2d4750eed7bb25bec5e09d83d12b039f443fbaac4662964cfdab2e3
-size 26295
+oid sha256:8e7311f2509d3aa68453a1469e73e88ba8aa5f9a1c08f8d9245368ed2af13525
+size 25850

--- a/Source/TinySurvivor/Public/GAS/GC/Gimmick/GC_ElectricShock_Material.h
+++ b/Source/TinySurvivor/Public/GAS/GC/Gimmick/GC_ElectricShock_Material.h
@@ -9,6 +9,8 @@
 /*
 	전기 감전 상태의 머티리얼 효과 GameplayCue
 	- 해골 모양의 머티리얼로 깜빡임 효과와 감전 사운드 적용
+	- 플레이어 원본 스킨과 해골 머티리얼 간 깜빡임 효과
+	- 해골 스킨 플레이어는 반전 효과 적용 (화이트 배경 + 검은 해골)
 	- Replicated 환경에서 모든 클라이언트에서 실행됨
 */
 UCLASS()
@@ -82,24 +84,28 @@ public:
 	
 #pragma region MaterialSettings
 private:
-	// 기본 머티리얼 경로
-	UPROPERTY(EditDefaultsOnly, Category = "Material Settings",
-		meta = (AllowPrivateAccess = "true"))
-	FString DefaultMaterialPath =
-		TEXT("/Game/ThirdParty/CardboardWarrior/Materials/Mat_Cardboard_warrior_Body");
+	// // 기본 머티리얼 경로
+	// UPROPERTY(EditDefaultsOnly, Category = "Material Settings",
+	// 	meta = (AllowPrivateAccess = "true"))
+	// FString DefaultMaterialPath =
+	// 	TEXT("/Game/ThirdParty/CardboardWarrior/Materials/Mat_Cardboard_warrior_Body");
 	
-	// 해골 머티리얼 경로
+	// 해골 머티리얼 경로 (검은 배경 + 흰 해골)
 	UPROPERTY(EditDefaultsOnly, Category = "Material Settings",
 		meta = (AllowPrivateAccess = "true"))
-	FString SkullMaterialPath =
+	FString BlackSkullMaterialPath =
 		TEXT("/Game/ThirdParty/Cardboard_Boy_SkinPack/Materials/Mat_Cardboard_warrior_Body_skin1");
 	
-	// 화이트 머티리얼 (런타임 생성용 베이스)
+	// 해골 스킨용 반전 머티리얼 경로 (화이트 배경 + 검은 해골)
 	UPROPERTY(EditDefaultsOnly, Category = "Material Settings",
 		meta = (AllowPrivateAccess = "true"))
-	//FString WhiteMaterialPath = TEXT("/Engine/EngineMaterials/DefaultMaterial");
-	FString WhiteMaterialPath =
-		TEXT("/Game/ThirdParty/CardboardWarrior/Materials/Mat_Cardboard_warrior_Body");
+	FString WhiteSkullMaterialPath =
+		TEXT("/Game/ThirdParty/Cardboard_Boy_SkinPack/Materials/Mat_Cardboard_warrior_Body_skin4");
+	
+	// 해골 스킨 감지용 키워드
+	UPROPERTY(EditDefaultsOnly, Category = "Material Settings",
+		meta = (AllowPrivateAccess = "true"))
+	FString SkullSkinKeyword = TEXT("skin1");
 	
 	// 깜빡임 횟수
 	UPROPERTY(EditDefaultsOnly, Category = "Material Settings",
@@ -111,10 +117,30 @@ private:
 		meta = (AllowPrivateAccess = "true"))
 	float BlinkInterval = 0.3f;
 	
-	// 화이트 머티리얼 색상
+	// 일반 스킨용 화이트 색상 (밝은 흰색)
 	UPROPERTY(EditDefaultsOnly, Category = "Material Settings",
 		meta = (AllowPrivateAccess = "true"))
-	FLinearColor WhiteColor = FLinearColor::White;
+	FLinearColor NormalWhiteColor = FLinearColor(1.0f, 1.0f, 1.0f, 1.0f);
+	
+	// 일반 스킨용 Emissive 강도
+	UPROPERTY(EditDefaultsOnly, Category = "Material Settings",
+		meta = (AllowPrivateAccess = "true"))
+	float NormalEmissiveStrength = 10.0f;
+	
+	// 해골 스킨용 반전 색상 (검은 해골)
+	UPROPERTY(EditDefaultsOnly, Category = "Material Settings",
+		meta = (AllowPrivateAccess = "true"))
+	FLinearColor InvertedSkullColor = FLinearColor(0.0f, 0.0f, 0.0f, 1.0f);
+	
+	// 해골 스킨용 배경 색상 (화이트)
+	UPROPERTY(EditDefaultsOnly, Category = "Material Settings",
+		meta = (AllowPrivateAccess = "true"))
+	FLinearColor InvertedBackgroundColor = FLinearColor(1.0f, 1.0f, 1.0f, 1.0f);
+	
+	// 해골 스킨용 Emissive 강도
+	UPROPERTY(EditDefaultsOnly, Category = "Material Settings",
+		meta = (AllowPrivateAccess = "true"))
+	float InvertedEmissiveStrength = 5.0f;
 	
 	// 전기 마비 사운드 큐
 	UPROPERTY(EditDefaultsOnly, Category = "Material Settings|Sound",
@@ -136,15 +162,16 @@ private:
 	// 원본 머티리얼 캐시
 	TArray<UMaterialInterface*> OriginalMaterials;
 	
-	// 로드된 머티리얼들
-	UPROPERTY()
-	UMaterialInterface* DefaultMaterial;
+	// 해골 스킨 여부 (반전 효과 적용)
+	bool bIsSkullSkin = false;
 	
+	// 로드된 해골 머티리얼 (검은 배경 + 흰 해골)
 	UPROPERTY()
-	UMaterialInterface* SkullMaterial;
+	UMaterialInterface* BlackSkullMaterial;
 	
+	// 로드된 반전 해골 머티리얼 (화이트 배경 + 검은 해골)
 	UPROPERTY()
-	UMaterialInstanceDynamic* WhiteMaterialInstance;
+	UMaterialInterface* WhiteSkullMaterial;
 	
 	// 재생 중인 오디오 컴포넌트
 	UPROPERTY()
@@ -157,9 +184,9 @@ private:
 		필요한 머티리얼 로드 및 Dynamic Material 생성
 		
 		동작 흐름:
-			1. DefaultMaterial, SkullMaterial StaticLoad
-			2. WhiteMaterialPath로 Dynamic Material Instance 생성
-			3. BaseColor와 Emissive 파라미터 설정
+			1. BlackSkullMaterial 로드 (검은 배경 + 흰 해골)
+			2. 원본 머티리얼 기반으로 Dynamic Material Instance 생성
+			3. 해골 스킨 여부에 따라 색상 및 Emissive 파라미터 설정
 			
 		특징:
 			- 로드 실패 시 안전하게 fallback 사용
@@ -174,8 +201,8 @@ private:
 		타겟 액터의 원본 머티리얼 캐시
 		
 		동작 흐름:
-			1. 타겟 액터의 SkeletalMeshComponent 획득
-			2. GetMaterial() 반복으로 OriginalMaterials 배열에 저장
+			1. SkeletalMeshComponent의 모든 머티리얼 저장
+			2. SkullSkinKeyword 포함 여부로 bIsSkullSkin 설정
 			
 		특징:
 			- 깜빡임 종료 후 원본 머티리얼 복원용
@@ -206,11 +233,9 @@ private:
 		실제 깜빡임 토글 처리
 	
 		동작 흐름:
-			1. TargetActor 유효성 체크
-			2. CurrentBlinkCount 짝수 -> WhiteMaterialInstance 적용
-			3. CurrentBlinkCount 홀수 -> SkullMaterial 적용
-			4. CurrentBlinkCount 증가
-			5. BlinkCount*2 도달 시 타이머 정리 및 원본 복원
+			1. CurrentBlinkCount 짝수 -> BlinkMaterial 적용
+			2. CurrentBlinkCount 홀수 -> 원본 머티리얼 적용
+			3. 해골 스킨의 경우 BlinkMaterial에 반전 색상 적용
 	
 		특징:
 			- BlinkCount에 따라 깜빡임 횟수 자동 계산
@@ -231,7 +256,7 @@ private:
 		특징:
 			- 깜빡임이나 상태 변경 시 반복 사용
 	*/
-	void ApplyMaterialToActor(AActor* Target, UMaterialInterface* Material);
+	void ApplyMaterialToActor(AActor* Target, const TArray<UMaterialInterface*>& Materials);
 #pragma endregion
 	
 #pragma region RestoreOriginalMaterials


### PR DESCRIPTION
- GC_Poison_Material.uasset
  - Poison Overlay Material 특정 설정 제거
  - 상황에 따라 적용되도록 수정
- BP_Zone_Poison.uasset
  - 디버깅 내용 Off 처리
- BP_Zone_ElectricShock.uasset
  - 디버깅 내용 Off 처리
- BP_Zone_SpeedDecrease.uasset
  - 디버깅 내용 Off 처리
  - 머티리얼 전환 내용 제거
- BP_Zone_SpeedIncrease.uasset
  - 디버깅 내용 Off 처리
  - 머티리얼 전환 내용 제거
- GC_ElectricShock_Material.h/cpp
  - 전기 감전 효과 해골 스킨 반전 머티리얼 적용
  - 해골 스킨(skin1) 플레이어 전용 반전 머티리얼(skin4) 추가
  - Dynamic Material 방식 제거, 고정 머티리얼 로드 방식으로 변경
  - 일반 스킨: 원본 ↔ 검은 해골(skin1) 깜빡임
  - 해골 스킨: 원본(skin1) ↔ 화이트 해골(skin4) 깜빡임